### PR TITLE
ROOT/GSL integrator

### DIFF
--- a/data/examples/epic_scenario_DVCS.xml
+++ b/data/examples/epic_scenario_DVCS.xml
@@ -59,9 +59,6 @@
 
       <!-- Generator module configuration -->
       <generator_configuration>
-         <!--<module type="EventGeneratorModule" name="EventGeneratorROOT">
-           <param name="type" value="miser"/>
-         </module>-->
          <module type="EventGeneratorModule" name="EventGeneratorFOAM">
          	<param name="nCells" value="1000" />
          	<param name="nSamples" value="1000" />

--- a/data/examples/epic_scenario_DVCS.xml
+++ b/data/examples/epic_scenario_DVCS.xml
@@ -59,6 +59,9 @@
 
       <!-- Generator module configuration -->
       <generator_configuration>
+         <!--<module type="EventGeneratorModule" name="EventGeneratorROOT">
+           <param name="type" value="miser"/>
+         </module>-->
          <module type="EventGeneratorModule" name="EventGeneratorFOAM">
          	<param name="nCells" value="1000" />
          	<param name="nSamples" value="1000" />

--- a/include/modules/event_generator/EventGeneratorROOT.h
+++ b/include/modules/event_generator/EventGeneratorROOT.h
@@ -1,0 +1,102 @@
+/*
+ * EventGeneratorROOT.h
+ *
+ *  Created on: Feb 2, 2024
+ *      Author: Laurent Forthomme (AGH)
+ */
+
+#ifndef MODULES_EVENT_GENERATOR_EVENTGENERATORROOT_H_
+#define MODULES_EVENT_GENERATOR_EVENTGENERATORROOT_H_
+
+#include <ElementaryUtils/parameters/Parameters.h>
+#include <Rtypes.h>
+#include <stddef.h>
+#include <Math/IntegratorMultiDim.h>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "../../beans/containers/KinematicRange.h"
+#include "EventGeneratorModule.h"
+
+class TFile;
+
+class TRandom;
+
+namespace EPIC {
+
+/**
+ * @class EventGeneratorROOT
+ *
+ * @brief Event generator based on ROOT library.
+ *
+ * This is event generator module based on ROOT library.
+ */
+class EventGeneratorROOT: public EventGeneratorModule {
+public:
+	static const std::string PARAMETER_NAME_TYPE; ///< Key to set EventGeneratorROOT::m_type.
+	static const std::string PARAMETER_NAME_ABSTOL; ///< Key to set EventGeneratorROOT::m_absTol.
+	static const std::string PARAMETER_NAME_RELTOL; ///< Key to set EventGeneratorROOT::m_relTol.
+	static const std::string PARAMETER_NAME_NBIN; ///< Key to set EventGeneratorROOT::m_nBin.
+
+	static const unsigned int classId; ///< Unique ID to automatically register
+									   /// the class in the registry.
+
+	/**
+	 * Default constructor.
+	 */
+	EventGeneratorROOT(const std::string &className);
+
+	/**
+	 * Copy constructor.
+	 */
+	EventGeneratorROOT(const EventGeneratorROOT &other);
+
+	/**
+	 * Destructor.
+	 */
+	virtual ~EventGeneratorROOT();
+
+	virtual EventGeneratorROOT *clone() const;
+	virtual void configure(const ElemUtils::Parameters &parameters);
+
+	virtual void initialise(const std::vector<KinematicRange> &kinematicRanges,
+			const EventGeneratorInterface &service);
+	virtual std::pair<std::vector<double>, double> generateEvent();
+	virtual std::pair<double, double> getIntegral();
+
+private:
+
+	/**
+	 * Scale value to range.
+	 */
+	double scaleValue(const KinematicRange& range, double value) const;
+
+	/**
+	 * Unscale value from range.
+	 */
+	double unscaleValue(const KinematicRange& range, double value) const;
+
+	/**
+	 * Get volume based on kinematic ranges.
+	 */
+	double getVolume() const;
+
+	ROOT::Math::IntegratorMultiDim *m_pROOT{nullptr};     ///< Pointer to ROOT integrator object.
+	TRandom *m_pRandom{nullptr}; ///< Pointer to ROOT TRandom object.
+	TFile* m_rootFile{nullptr}; ///< Pointer to ROOT file.
+
+	const EventGeneratorInterface *m_pEventGeneratorInterface{nullptr}; ///< Pointer used
+															   /// during
+	/// initialization of ROOT.
+	std::vector<KinematicRange> m_kinematicRanges; ///< Kinematic ranges set during initialization.
+
+	std::string m_type{"vegas"}; ///< Type of integration algorithm.
+	double m_absTol{-1.}; ///< Maximum absolute uncertainty.
+	double m_relTol{-1.}; ///< Maximum relative uncertainty.
+	size_t m_nBin{0};   ///< Number of bins in build-up.
+};
+
+} /* namespace EPIC */
+
+#endif /* MODULES_EVENT_GENERATOR_EVENTGENERATORROOT_H_ */

--- a/include/modules/event_generator/EventGeneratorROOT.h
+++ b/include/modules/event_generator/EventGeneratorROOT.h
@@ -9,9 +9,10 @@
 #define MODULES_EVENT_GENERATOR_EVENTGENERATORROOT_H_
 
 #include <ElementaryUtils/parameters/Parameters.h>
+#include <Math/IntegratorMultiDim.h>
 #include <Rtypes.h>
 #include <stddef.h>
-#include <Math/IntegratorMultiDim.h>
+
 #include <string>
 #include <utility>
 #include <vector>
@@ -19,84 +20,44 @@
 #include "../../beans/containers/KinematicRange.h"
 #include "EventGeneratorModule.h"
 
-class TFile;
-
-class TRandom;
-
 namespace EPIC {
+  /**
+   * @class EventGeneratorROOT
+   *
+   * @brief Event generator based on ROOT IntegratorMultiDim.
+   */
+  class EventGeneratorROOT : public EventGeneratorModule {
+  public:
+    static const std::string PARAMETER_NAME_TYPE;    ///< Key to set EventGeneratorROOT::m_type.
+    static const std::string PARAMETER_NAME_ABSTOL;  ///< Key to set EventGeneratorROOT::m_absTol.
+    static const std::string PARAMETER_NAME_RELTOL;  ///< Key to set EventGeneratorROOT::m_relTol.
+    static const std::string PARAMETER_NAME_NBIN;    ///< Key to set EventGeneratorROOT::m_nBin.
 
-/**
- * @class EventGeneratorROOT
- *
- * @brief Event generator based on ROOT library.
- *
- * This is event generator module based on ROOT library.
- */
-class EventGeneratorROOT: public EventGeneratorModule {
-public:
-	static const std::string PARAMETER_NAME_TYPE; ///< Key to set EventGeneratorROOT::m_type.
-	static const std::string PARAMETER_NAME_ABSTOL; ///< Key to set EventGeneratorROOT::m_absTol.
-	static const std::string PARAMETER_NAME_RELTOL; ///< Key to set EventGeneratorROOT::m_relTol.
-	static const std::string PARAMETER_NAME_NBIN; ///< Key to set EventGeneratorROOT::m_nBin.
+    static const unsigned int classId;  ///< Unique ID to automatically register the class in the registry.
 
-	static const unsigned int classId; ///< Unique ID to automatically register
-									   /// the class in the registry.
+    EventGeneratorROOT(const std::string &className);     ///< Default constructor
+    EventGeneratorROOT(const EventGeneratorROOT &other);  ///< Copy constructor
+    virtual ~EventGeneratorROOT();                        ///< Destructor
 
-	/**
-	 * Default constructor.
-	 */
-	EventGeneratorROOT(const std::string &className);
+    virtual EventGeneratorROOT *clone() const;
+    virtual void configure(const ElemUtils::Parameters &parameters);
 
-	/**
-	 * Copy constructor.
-	 */
-	EventGeneratorROOT(const EventGeneratorROOT &other);
+    virtual void initialise(const std::vector<KinematicRange> &kinematicRanges, const EventGeneratorInterface &service);
+    virtual std::pair<std::vector<double>, double> generateEvent();
+    virtual std::pair<double, double> getIntegral();
 
-	/**
-	 * Destructor.
-	 */
-	virtual ~EventGeneratorROOT();
+  private:
+    ROOT::Math::IntegratorMultiDim *m_pROOT{nullptr};  ///< Pointer to ROOT integrator object.
 
-	virtual EventGeneratorROOT *clone() const;
-	virtual void configure(const ElemUtils::Parameters &parameters);
+    /// Pointer used during initialization of ROOT.
+    const EventGeneratorInterface *m_pEventGeneratorInterface{nullptr};
+    std::vector<KinematicRange> m_kinematicRanges;  ///< Kinematic ranges set during initialization.
 
-	virtual void initialise(const std::vector<KinematicRange> &kinematicRanges,
-			const EventGeneratorInterface &service);
-	virtual std::pair<std::vector<double>, double> generateEvent();
-	virtual std::pair<double, double> getIntegral();
+    std::string m_type{"vegas"};  ///< Type of integration algorithm.
+    double m_absTol{-1.};         ///< Maximum absolute uncertainty.
+    double m_relTol{-1.};         ///< Maximum relative uncertainty.
+    size_t m_nBin{0};             ///< Number of bins in build-up.
+  };
+}  // namespace EPIC
 
-private:
-
-	/**
-	 * Scale value to range.
-	 */
-	double scaleValue(const KinematicRange& range, double value) const;
-
-	/**
-	 * Unscale value from range.
-	 */
-	double unscaleValue(const KinematicRange& range, double value) const;
-
-	/**
-	 * Get volume based on kinematic ranges.
-	 */
-	double getVolume() const;
-
-	ROOT::Math::IntegratorMultiDim *m_pROOT{nullptr};     ///< Pointer to ROOT integrator object.
-	TRandom *m_pRandom{nullptr}; ///< Pointer to ROOT TRandom object.
-	TFile* m_rootFile{nullptr}; ///< Pointer to ROOT file.
-
-	const EventGeneratorInterface *m_pEventGeneratorInterface{nullptr}; ///< Pointer used
-															   /// during
-	/// initialization of ROOT.
-	std::vector<KinematicRange> m_kinematicRanges; ///< Kinematic ranges set during initialization.
-
-	std::string m_type{"vegas"}; ///< Type of integration algorithm.
-	double m_absTol{-1.}; ///< Maximum absolute uncertainty.
-	double m_relTol{-1.}; ///< Maximum relative uncertainty.
-	size_t m_nBin{0};   ///< Number of bins in build-up.
-};
-
-} /* namespace EPIC */
-
-#endif /* MODULES_EVENT_GENERATOR_EVENTGENERATORROOT_H_ */
+#endif

--- a/include/modules/event_generator/EventGeneratorROOT.h
+++ b/include/modules/event_generator/EventGeneratorROOT.h
@@ -57,6 +57,8 @@ namespace EPIC {
     double m_absTol{-1.};         ///< Maximum absolute uncertainty.
     double m_relTol{-1.};         ///< Maximum relative uncertainty.
     size_t m_nBin{0};             ///< Number of bins in build-up.
+
+    std::pair<double, double> m_integral{0., 0.};  ///< Integrated cross section + uncertainty
   };
 }  // namespace EPIC
 

--- a/include/services/GeneratorService.h
+++ b/include/services/GeneratorService.h
@@ -485,7 +485,7 @@ protected:
         }
 
         if (m_generalConfiguration.getNEvents() == 0) {
-            throw ElemUtils::CustomException(getClassName(), __func__,
+            info(__func__,
                     "Number of events to be generated is: 0");
         }
     }

--- a/include/services/GeneratorService.h
+++ b/include/services/GeneratorService.h
@@ -485,7 +485,7 @@ protected:
         }
 
         if (m_generalConfiguration.getNEvents() == 0) {
-            info(__func__,
+            warn(__func__,
                     "Number of events to be generated is: 0");
         }
     }

--- a/src/modules/event_generator/EventGeneratorROOT.cpp
+++ b/src/modules/event_generator/EventGeneratorROOT.cpp
@@ -5,206 +5,147 @@
  *      Author: Laurent Forthomme (AGH)
  */
 
-#include "../../../include/modules/event_generator/EventGeneratorROOT.h"
-
 #include <ElementaryUtils/logger/CustomException.h>
 #include <ElementaryUtils/parameters/GenericType.h>
 #include <ElementaryUtils/string_utils/Formatter.h>
-#include <partons/BaseObjectRegistry.h>
-#include <partons/Partons.h>
-#include <partons/services/hash_sum/CryptographicHashService.h>
-#include <partons/ServiceObjectRegistry.h>
-#include <sys/stat.h>
 #include <TFile.h>
 #include <TRandom3.h>
+#include <partons/BaseObjectRegistry.h>
+#include <partons/Partons.h>
+#include <partons/ServiceObjectRegistry.h>
+#include <partons/services/hash_sum/CryptographicHashService.h>
+#include <sys/stat.h>
 
 #include "../../../include/beans/other/EventGeneratorInterface.h"
+#include "../../../include/modules/event_generator/EventGeneratorROOT.h"
 
 namespace EPIC {
 
-const std::string EventGeneratorROOT::PARAMETER_NAME_TYPE = "type";
-const std::string EventGeneratorROOT::PARAMETER_NAME_ABSTOL = "absTol";
-const std::string EventGeneratorROOT::PARAMETER_NAME_RELTOL = "relTol";
-const std::string EventGeneratorROOT::PARAMETER_NAME_NBIN = "nBins";
+  const std::string EventGeneratorROOT::PARAMETER_NAME_TYPE = "type";
+  const std::string EventGeneratorROOT::PARAMETER_NAME_ABSTOL = "absTol";
+  const std::string EventGeneratorROOT::PARAMETER_NAME_RELTOL = "relTol";
+  const std::string EventGeneratorROOT::PARAMETER_NAME_NBIN = "nBins";
 
-const unsigned int EventGeneratorROOT::classId =
-		PARTONS::BaseObjectRegistry::getInstance()->registerBaseObject(
-				new EventGeneratorROOT("EventGeneratorROOT"));
+  const unsigned int EventGeneratorROOT::classId =
+      PARTONS::BaseObjectRegistry::getInstance()->registerBaseObject(new EventGeneratorROOT("EventGeneratorROOT"));
 
-EventGeneratorROOT::EventGeneratorROOT(const std::string &className) :
-		EventGeneratorModule(className) {}
+  EventGeneratorROOT::EventGeneratorROOT(const std::string &className) : EventGeneratorModule(className) {}
 
-EventGeneratorROOT::EventGeneratorROOT(const EventGeneratorROOT &other) :
-		EventGeneratorModule(other) {
-	if (other.m_pROOT != nullptr)
-		warn(__func__, "Not able to copy ROOT object, you need to run "
-				"initialization for new object");
+  EventGeneratorROOT::EventGeneratorROOT(const EventGeneratorROOT &other) : EventGeneratorModule(other) {
+    if (other.m_pROOT != nullptr)
+      warn(__func__,
+           "Not able to copy ROOT object, you need to run "
+           "initialization for new object");
 
-	m_type = other.m_type;
-	m_absTol = other.m_absTol;
-	m_relTol = other.m_relTol;
-	m_nBin = other.m_nBin;
-}
-
-EventGeneratorROOT::~EventGeneratorROOT() {
-
-	if (m_pROOT) {
-		delete m_pROOT;
-		m_pROOT = nullptr;
-	}
-
-	if (m_pRandom != nullptr) {
-		delete m_pRandom;
-		m_pRandom = nullptr;
-	}
-
-	if (m_rootFile != nullptr) {
-		m_rootFile->Close();
-		m_rootFile = nullptr;
-	}
-}
-
-EventGeneratorROOT *EventGeneratorROOT::clone() const {
-	return new EventGeneratorROOT(*this);
-}
-
-void EventGeneratorROOT::configure(const ElemUtils::Parameters &parameters) {
-
-	EventGeneratorModule::configure(parameters);
-
-	if (parameters.isAvailable(EventGeneratorROOT::PARAMETER_NAME_TYPE)) {
-		m_type = parameters.getLastAvailable().toString();
-		info(__func__,
-				ElemUtils::Formatter() << "Parameter "
-						<< EventGeneratorROOT::PARAMETER_NAME_TYPE
-						<< " changed to " << m_type);
-	}
-
-	if (parameters.isAvailable(EventGeneratorROOT::PARAMETER_NAME_ABSTOL)) {
-		m_absTol = parameters.getLastAvailable().toDouble();
-		info(__func__,
-				ElemUtils::Formatter() << "Parameter "
-						<< EventGeneratorROOT::PARAMETER_NAME_ABSTOL
-						<< " changed to " << m_absTol);
-	}
-
-	if (parameters.isAvailable(EventGeneratorROOT::PARAMETER_NAME_RELTOL)) {
-		m_relTol = parameters.getLastAvailable().toDouble();
-		info(__func__,
-				ElemUtils::Formatter() << "Parameter "
-						<< EventGeneratorROOT::PARAMETER_NAME_RELTOL
-						<< " changed to " << m_relTol);
-	}
-
-	if (parameters.isAvailable(EventGeneratorROOT::PARAMETER_NAME_NBIN)) {
-		m_nBin = parameters.getLastAvailable().toUInt();
-		info(__func__,
-				ElemUtils::Formatter() << "Parameter "
-						<< EventGeneratorROOT::PARAMETER_NAME_NBIN
-						<< " changed to " << m_nBin);
-	}
-}
-
-void EventGeneratorROOT::initialise(
-		const std::vector<KinematicRange> &kinematicRanges,
-		const EventGeneratorInterface &service) {
-
-	//scenario
-	size_t scenario = 0;
-
-	if (!m_initStatePath.empty()) {
-		struct stat buffer;  //check if file exist
-		if (!stat(m_initStatePath.c_str(), &buffer) == 0)  //no
-			scenario = 1;
-		else  //yes
-			scenario = 2;
-	}
-
-	// random number generator (create)
-	m_pRandom = new TRandom3(m_seed);
-
-	// kinematic ranges
-	m_kinematicRanges = kinematicRanges;
-
-	// pointer
-	m_pEventGeneratorInterface = &service;
-
-	// initialize
-	if (scenario == 0 || scenario == 1) {
-		info(__func__, "Creating new ROOT integrator object");
-		// parameters
-    ROOT::Math::IntegratorMultiDim::Type type;
-    if (m_type == "default")
-      type = ROOT::Math::IntegratorMultiDim::Type::kDEFAULT;
-    else if (m_type == "adaptive")
-      type = ROOT::Math::IntegratorMultiDim::Type::kADAPTIVE;
-    else if (m_type == "plain")
-      type = ROOT::Math::IntegratorMultiDim::Type::kPLAIN;
-    else if (m_type == "miser")
-      type = ROOT::Math::IntegratorMultiDim::Type::kMISER;
-    else if (m_type == "vegas")
-      type = ROOT::Math::IntegratorMultiDim::Type::kVEGAS;
-    else
-      throw ElemUtils::CustomException(getClassName(), __func__,
-          ElemUtils::Formatter() << "Invalid type retrieved: " << m_type);
-    m_pROOT = new ROOT::Math::IntegratorMultiDim(type, m_absTol, m_relTol, m_nBin);
-
-    if (m_pEventGeneratorInterface == nullptr)
-      throw ElemUtils::CustomException(getClassName(), __func__,
-          "Pointer to EventGenerator is null");
-    if (m_kinematicRanges.size() != kinematicRanges.size())
-      throw ElemUtils::CustomException(getClassName(), __func__,
-          "Size of vector containing  kinematic ranges different than nDim");
-    auto density = [&](const double* x) -> double {
-      std::vector<double> v(kinematicRanges.size());
-      for (size_t i = 0; i < kinematicRanges.size(); i++)
-        v.at(i) = unscaleValue(m_kinematicRanges.at(i), x[i]);
-      return m_pEventGeneratorInterface->getEventDistribution(v);
-    };
-    m_pROOT->SetFunction(density, kinematicRanges.size() /* number of dimensions */);
-	}
-}
-
-std::pair<std::vector<double>, double> EventGeneratorROOT::generateEvent() {
-	throw ElemUtils::CustomException(getClassName(), __func__, "Module is not yet ready for event generation");
-}
-
-std::pair<double, double> EventGeneratorROOT::getIntegral() {
-  std::vector<double> xmin, xmax;
-	for (const auto& range : m_kinematicRanges) {
-		xmin.emplace_back(range.getMin());
-    xmax.emplace_back(range.getMax());
+    m_type = other.m_type;
+    m_absTol = other.m_absTol;
+    m_relTol = other.m_relTol;
+    m_nBin = other.m_nBin;
   }
-	if (!m_pROOT)
-		throw ElemUtils::CustomException(getClassName(), __func__,
-				"Pointer to ROOT integrator object is null");
-	const auto integral = m_pROOT->Integral(xmin.data(), xmax.data()), error = m_pROOT->Error();
-  const auto volume = getVolume();
-	return std::make_pair(volume * integral, volume * error);
-}
 
-double EventGeneratorROOT::scaleValue(const KinematicRange& range, double value) const {
-	const auto minScaled = range.getMin(), maxScaled = range.getMax();
-	if (value < minScaled || value > maxScaled)
-		throw ElemUtils::CustomException(getClassName(), __func__,
-				ElemUtils::Formatter() << "Value outside the limits: "
-						<< value);
-	return (value - minScaled) / (maxScaled - minScaled);
-}
+  EventGeneratorROOT::~EventGeneratorROOT() {
+    if (m_pROOT)
+      delete m_pROOT;
+  }
 
-double EventGeneratorROOT::unscaleValue(const KinematicRange& range, double value) const {
-	const auto minScaled = range.getMin(), maxScaled = range.getMax();
-	if (value < 0. || value > 1.)
-		throw ElemUtils::CustomException(getClassName(), __func__,
-				ElemUtils::Formatter() << "Value outside the limits: " << value);
-	return minScaled + value * (maxScaled - minScaled);
-}
+  EventGeneratorROOT *EventGeneratorROOT::clone() const { return new EventGeneratorROOT(*this); }
 
-double EventGeneratorROOT::getVolume() const {
-	double result = 1.;
-	for (const auto& range : m_kinematicRanges)
-		result *= range.getMax() - range.getMin();
-	return result;
-}
+  void EventGeneratorROOT::configure(const ElemUtils::Parameters &parameters) {
+    EventGeneratorModule::configure(parameters);
+
+    if (parameters.isAvailable(EventGeneratorROOT::PARAMETER_NAME_TYPE)) {
+      m_type = parameters.getLastAvailable().getString();
+      info(__func__,
+           ElemUtils::Formatter() << "Parameter " << EventGeneratorROOT::PARAMETER_NAME_TYPE << " changed to "
+                                  << m_type);
+    }
+
+    if (parameters.isAvailable(EventGeneratorROOT::PARAMETER_NAME_ABSTOL)) {
+      m_absTol = parameters.getLastAvailable().toDouble();
+      info(__func__,
+           ElemUtils::Formatter() << "Parameter " << EventGeneratorROOT::PARAMETER_NAME_ABSTOL << " changed to "
+                                  << m_absTol);
+    }
+
+    if (parameters.isAvailable(EventGeneratorROOT::PARAMETER_NAME_RELTOL)) {
+      m_relTol = parameters.getLastAvailable().toDouble();
+      info(__func__,
+           ElemUtils::Formatter() << "Parameter " << EventGeneratorROOT::PARAMETER_NAME_RELTOL << " changed to "
+                                  << m_relTol);
+    }
+
+    if (parameters.isAvailable(EventGeneratorROOT::PARAMETER_NAME_NBIN)) {
+      m_nBin = parameters.getLastAvailable().toUInt();
+      info(__func__,
+           ElemUtils::Formatter() << "Parameter " << EventGeneratorROOT::PARAMETER_NAME_NBIN << " changed to "
+                                  << m_nBin);
+    }
+  }
+
+  void EventGeneratorROOT::initialise(const std::vector<KinematicRange> &kinematicRanges,
+                                      const EventGeneratorInterface &service) {
+    //scenario
+    size_t scenario = 0;
+
+    if (!m_initStatePath.empty()) {
+      struct stat buffer;
+      if (!stat(m_initStatePath.c_str(), &buffer) == 0)  // file does not exist
+        scenario = 1;
+      else  // file exists
+        scenario = 2;
+    }
+
+    m_kinematicRanges = kinematicRanges;
+    m_pEventGeneratorInterface = &service;
+
+    // initialize
+    if (scenario == 0 || scenario == 1) {
+      info(__func__, "Creating new ROOT integrator object");
+      // parameters
+      ROOT::Math::IntegratorMultiDim::Type type;
+      if (m_type == "default")
+        type = ROOT::Math::IntegratorMultiDim::Type::kDEFAULT;
+      else if (m_type == "adaptive")
+        type = ROOT::Math::IntegratorMultiDim::Type::kADAPTIVE;
+      else if (m_type == "plain")
+        type = ROOT::Math::IntegratorMultiDim::Type::kPLAIN;
+      else if (m_type == "miser")
+        type = ROOT::Math::IntegratorMultiDim::Type::kMISER;
+      else if (m_type == "vegas")
+        type = ROOT::Math::IntegratorMultiDim::Type::kVEGAS;
+      else
+        throw ElemUtils::CustomException(
+            getClassName(), __func__, ElemUtils::Formatter() << "Invalid type retrieved: " << m_type);
+      m_pROOT = new ROOT::Math::IntegratorMultiDim(type, m_absTol, m_relTol, m_nBin);
+
+      if (m_pEventGeneratorInterface == nullptr)
+        throw ElemUtils::CustomException(getClassName(), __func__, "Pointer to EventGenerator is null");
+      if (m_kinematicRanges.size() != kinematicRanges.size())
+        throw ElemUtils::CustomException(
+            getClassName(), __func__, "Size of vector containing  kinematic ranges different than nDim");
+      static const auto density = [&](const double *x) -> double {
+        std::vector<double> v(kinematicRanges.size());
+        for (size_t i = 0; i < kinematicRanges.size(); i++)
+          v.at(i) = x[i];
+        return m_pEventGeneratorInterface->getEventDistribution(v);
+      };
+      m_pROOT->SetFunction(density, kinematicRanges.size() /* number of dimensions */);
+    }
+  }
+
+  std::pair<std::vector<double>, double> EventGeneratorROOT::generateEvent() {
+    throw ElemUtils::CustomException(getClassName(), __func__, "Module is not yet ready for event generation");
+  }
+
+  std::pair<double, double> EventGeneratorROOT::getIntegral() {
+    std::vector<double> xmin, xmax;
+    for (const auto &range : m_kinematicRanges) {
+      xmin.emplace_back(range.getMin());
+      xmax.emplace_back(range.getMax());
+    }
+    if (!m_pROOT)
+      throw ElemUtils::CustomException(getClassName(), __func__, "Pointer to ROOT integrator object is null");
+    return std::make_pair(m_pROOT->Integral(xmin.data(), xmax.data()), m_pROOT->Error());
+  }
 
 } /* namespace EPIC */

--- a/src/modules/event_generator/EventGeneratorROOT.cpp
+++ b/src/modules/event_generator/EventGeneratorROOT.cpp
@@ -138,6 +138,15 @@ namespace EPIC {
         return m_pEventGeneratorInterface->getEventDistribution(v);
       };
       m_pROOT->SetFunction(density, kinematicRanges.size() /* number of dimensions */);
+      std::vector<double> xmin, xmax;
+      for (const auto &range : m_kinematicRanges) {
+        xmin.emplace_back(range.getMin());
+        xmax.emplace_back(range.getMax());
+      }
+      if (!m_pROOT)
+        throw ElemUtils::CustomException(getClassName(), __func__, "Pointer to ROOT integrator object is null");
+      const auto integral = m_pROOT->Integral(xmin.data(), xmax.data()), uncertainty = m_pROOT->Error();
+      m_integral = std::make_pair(integral, uncertainty);
     }
   }
 
@@ -145,16 +154,6 @@ namespace EPIC {
     throw ElemUtils::CustomException(getClassName(), __func__, "Module is not yet ready for event generation");
   }
 
-  std::pair<double, double> EventGeneratorROOT::getIntegral() {
-    std::vector<double> xmin, xmax;
-    for (const auto &range : m_kinematicRanges) {
-      xmin.emplace_back(range.getMin());
-      xmax.emplace_back(range.getMax());
-    }
-    if (!m_pROOT)
-      throw ElemUtils::CustomException(getClassName(), __func__, "Pointer to ROOT integrator object is null");
-    const auto integral = m_pROOT->Integral(xmin.data(), xmax.data()), uncertainty = m_pROOT->Error();
-    return std::make_pair(integral, uncertainty);
-  }
+  std::pair<double, double> EventGeneratorROOT::getIntegral() { return m_integral; }
 
 } /* namespace EPIC */

--- a/src/modules/event_generator/EventGeneratorROOT.cpp
+++ b/src/modules/event_generator/EventGeneratorROOT.cpp
@@ -117,6 +117,14 @@ namespace EPIC {
         throw ElemUtils::CustomException(
             getClassName(), __func__, ElemUtils::Formatter() << "Invalid type retrieved: " << m_type);
       m_pROOT = new ROOT::Math::IntegratorMultiDim(type, m_absTol, m_relTol, m_nBin);
+      m_pROOT->Options().SetAbsTolerance(m_absTol);
+      m_pROOT->Options().SetRelTolerance(m_relTol);
+      m_pROOT->Options().SetWKSize(m_nBin);
+      {
+        std::ostringstream os;
+        m_pROOT->Options().Print(os);
+        info(__func__, ElemUtils::Formatter() << "List of options for ROOT integrator\n" << os.str());
+      }
 
       if (m_pEventGeneratorInterface == nullptr)
         throw ElemUtils::CustomException(getClassName(), __func__, "Pointer to EventGenerator is null");

--- a/src/modules/event_generator/EventGeneratorROOT.cpp
+++ b/src/modules/event_generator/EventGeneratorROOT.cpp
@@ -145,7 +145,8 @@ namespace EPIC {
     }
     if (!m_pROOT)
       throw ElemUtils::CustomException(getClassName(), __func__, "Pointer to ROOT integrator object is null");
-    return std::make_pair(m_pROOT->Integral(xmin.data(), xmax.data()), m_pROOT->Error());
+    const auto integral = m_pROOT->Integral(xmin.data(), xmax.data()), uncertainty = m_pROOT->Error();
+    return std::make_pair(integral, uncertainty);
   }
 
 } /* namespace EPIC */

--- a/src/modules/event_generator/EventGeneratorROOT.cpp
+++ b/src/modules/event_generator/EventGeneratorROOT.cpp
@@ -1,0 +1,210 @@
+/*
+ * EventGeneratorROOT.cpp
+ *
+ *  Created on: Feb 1, 2024
+ *      Author: Laurent Forthomme (AGH)
+ */
+
+#include "../../../include/modules/event_generator/EventGeneratorROOT.h"
+
+#include <ElementaryUtils/logger/CustomException.h>
+#include <ElementaryUtils/parameters/GenericType.h>
+#include <ElementaryUtils/string_utils/Formatter.h>
+#include <partons/BaseObjectRegistry.h>
+#include <partons/Partons.h>
+#include <partons/services/hash_sum/CryptographicHashService.h>
+#include <partons/ServiceObjectRegistry.h>
+#include <sys/stat.h>
+#include <TFile.h>
+#include <TRandom3.h>
+
+#include "../../../include/beans/other/EventGeneratorInterface.h"
+
+namespace EPIC {
+
+const std::string EventGeneratorROOT::PARAMETER_NAME_TYPE = "type";
+const std::string EventGeneratorROOT::PARAMETER_NAME_ABSTOL = "absTol";
+const std::string EventGeneratorROOT::PARAMETER_NAME_RELTOL = "relTol";
+const std::string EventGeneratorROOT::PARAMETER_NAME_NBIN = "nBins";
+
+const unsigned int EventGeneratorROOT::classId =
+		PARTONS::BaseObjectRegistry::getInstance()->registerBaseObject(
+				new EventGeneratorROOT("EventGeneratorROOT"));
+
+EventGeneratorROOT::EventGeneratorROOT(const std::string &className) :
+		EventGeneratorModule(className) {}
+
+EventGeneratorROOT::EventGeneratorROOT(const EventGeneratorROOT &other) :
+		EventGeneratorModule(other) {
+	if (other.m_pROOT != nullptr)
+		warn(__func__, "Not able to copy ROOT object, you need to run "
+				"initialization for new object");
+
+	m_type = other.m_type;
+	m_absTol = other.m_absTol;
+	m_relTol = other.m_relTol;
+	m_nBin = other.m_nBin;
+}
+
+EventGeneratorROOT::~EventGeneratorROOT() {
+
+	if (m_pROOT) {
+		delete m_pROOT;
+		m_pROOT = nullptr;
+	}
+
+	if (m_pRandom != nullptr) {
+		delete m_pRandom;
+		m_pRandom = nullptr;
+	}
+
+	if (m_rootFile != nullptr) {
+		m_rootFile->Close();
+		m_rootFile = nullptr;
+	}
+}
+
+EventGeneratorROOT *EventGeneratorROOT::clone() const {
+	return new EventGeneratorROOT(*this);
+}
+
+void EventGeneratorROOT::configure(const ElemUtils::Parameters &parameters) {
+
+	EventGeneratorModule::configure(parameters);
+
+	if (parameters.isAvailable(EventGeneratorROOT::PARAMETER_NAME_TYPE)) {
+		m_type = parameters.getLastAvailable().toString();
+		info(__func__,
+				ElemUtils::Formatter() << "Parameter "
+						<< EventGeneratorROOT::PARAMETER_NAME_TYPE
+						<< " changed to " << m_type);
+	}
+
+	if (parameters.isAvailable(EventGeneratorROOT::PARAMETER_NAME_ABSTOL)) {
+		m_absTol = parameters.getLastAvailable().toDouble();
+		info(__func__,
+				ElemUtils::Formatter() << "Parameter "
+						<< EventGeneratorROOT::PARAMETER_NAME_ABSTOL
+						<< " changed to " << m_absTol);
+	}
+
+	if (parameters.isAvailable(EventGeneratorROOT::PARAMETER_NAME_RELTOL)) {
+		m_relTol = parameters.getLastAvailable().toDouble();
+		info(__func__,
+				ElemUtils::Formatter() << "Parameter "
+						<< EventGeneratorROOT::PARAMETER_NAME_RELTOL
+						<< " changed to " << m_relTol);
+	}
+
+	if (parameters.isAvailable(EventGeneratorROOT::PARAMETER_NAME_NBIN)) {
+		m_nBin = parameters.getLastAvailable().toUInt();
+		info(__func__,
+				ElemUtils::Formatter() << "Parameter "
+						<< EventGeneratorROOT::PARAMETER_NAME_NBIN
+						<< " changed to " << m_nBin);
+	}
+}
+
+void EventGeneratorROOT::initialise(
+		const std::vector<KinematicRange> &kinematicRanges,
+		const EventGeneratorInterface &service) {
+
+	//scenario
+	size_t scenario = 0;
+
+	if (!m_initStatePath.empty()) {
+		struct stat buffer;  //check if file exist
+		if (!stat(m_initStatePath.c_str(), &buffer) == 0)  //no
+			scenario = 1;
+		else  //yes
+			scenario = 2;
+	}
+
+	// random number generator (create)
+	m_pRandom = new TRandom3(m_seed);
+
+	// kinematic ranges
+	m_kinematicRanges = kinematicRanges;
+
+	// pointer
+	m_pEventGeneratorInterface = &service;
+
+	// initialize
+	if (scenario == 0 || scenario == 1) {
+		info(__func__, "Creating new ROOT integrator object");
+		// parameters
+    ROOT::Math::IntegratorMultiDim::Type type;
+    if (m_type == "default")
+      type = ROOT::Math::IntegratorMultiDim::Type::kDEFAULT;
+    else if (m_type == "adaptive")
+      type = ROOT::Math::IntegratorMultiDim::Type::kADAPTIVE;
+    else if (m_type == "plain")
+      type = ROOT::Math::IntegratorMultiDim::Type::kPLAIN;
+    else if (m_type == "miser")
+      type = ROOT::Math::IntegratorMultiDim::Type::kMISER;
+    else if (m_type == "vegas")
+      type = ROOT::Math::IntegratorMultiDim::Type::kVEGAS;
+    else
+      throw ElemUtils::CustomException(getClassName(), __func__,
+          ElemUtils::Formatter() << "Invalid type retrieved: " << m_type);
+    m_pROOT = new ROOT::Math::IntegratorMultiDim(type, m_absTol, m_relTol, m_nBin);
+
+    if (m_pEventGeneratorInterface == nullptr)
+      throw ElemUtils::CustomException(getClassName(), __func__,
+          "Pointer to EventGenerator is null");
+    if (m_kinematicRanges.size() != kinematicRanges.size())
+      throw ElemUtils::CustomException(getClassName(), __func__,
+          "Size of vector containing  kinematic ranges different than nDim");
+    auto density = [&](const double* x) -> double {
+      std::vector<double> v(kinematicRanges.size());
+      for (size_t i = 0; i < kinematicRanges.size(); i++)
+        v.at(i) = unscaleValue(m_kinematicRanges.at(i), x[i]);
+      return m_pEventGeneratorInterface->getEventDistribution(v);
+    };
+    m_pROOT->SetFunction(density, kinematicRanges.size() /* number of dimensions */);
+	}
+}
+
+std::pair<std::vector<double>, double> EventGeneratorROOT::generateEvent() {
+	throw ElemUtils::CustomException(getClassName(), __func__, "Module is not yet ready for event generation");
+}
+
+std::pair<double, double> EventGeneratorROOT::getIntegral() {
+  std::vector<double> xmin, xmax;
+	for (const auto& range : m_kinematicRanges) {
+		xmin.emplace_back(range.getMin());
+    xmax.emplace_back(range.getMax());
+  }
+	if (!m_pROOT)
+		throw ElemUtils::CustomException(getClassName(), __func__,
+				"Pointer to ROOT integrator object is null");
+	const auto integral = m_pROOT->Integral(xmin.data(), xmax.data()), error = m_pROOT->Error();
+  const auto volume = getVolume();
+	return std::make_pair(volume * integral, volume * error);
+}
+
+double EventGeneratorROOT::scaleValue(const KinematicRange& range, double value) const {
+	const auto minScaled = range.getMin(), maxScaled = range.getMax();
+	if (value < minScaled || value > maxScaled)
+		throw ElemUtils::CustomException(getClassName(), __func__,
+				ElemUtils::Formatter() << "Value outside the limits: "
+						<< value);
+	return (value - minScaled) / (maxScaled - minScaled);
+}
+
+double EventGeneratorROOT::unscaleValue(const KinematicRange& range, double value) const {
+	const auto minScaled = range.getMin(), maxScaled = range.getMax();
+	if (value < 0. || value > 1.)
+		throw ElemUtils::CustomException(getClassName(), __func__,
+				ElemUtils::Formatter() << "Value outside the limits: " << value);
+	return minScaled + value * (maxScaled - minScaled);
+}
+
+double EventGeneratorROOT::getVolume() const {
+	double result = 1.;
+	for (const auto& range : m_kinematicRanges)
+		result *= range.getMax() - range.getMin();
+	return result;
+}
+
+} /* namespace EPIC */


### PR DESCRIPTION
This PR introduces a new "event_generator" module implementation, based on ROOT's [Math::IntegratorMultiDim](https://root.cern.ch/doc/master/classROOT_1_1Math_1_1IntegratorMultiDim.html).

It allows to compute cross sections with more numerical stability than the usual Foam method, thanks in particular to ROOT's C++ wrappers to GSL's Vegas, Miser, and plain [Monte Carlo integrator algorithms](https://www.gnu.org/software/gsl/doc/html/montecarlo.html) implementations.

This results in shorter runs for most algorithms used, and comparable or better precisions reached for a same run time. For instance, running the [epic_scenario_DVCS.xml](https://github.com/pawelsznajder/epic/blob/main/data/examples/epic_scenario_DVCS.xml) example on an 8th Gen Intel CORE i7 vPro with 16 Gb RAM:

- Foam (with 100k events generation upstream, 22'45" run):
  ```
  Integrated cross-section (value) [nb]: 4.745535713297
  Integrated cross-section (uncertainty) [nb]: 0.0190818197995742
  ```
- Plain (no event generation, 1'17" run):
  ```
  Integrated cross-section (value) [nb]: 4.88435227940284
  Integrated cross-section (uncertainty) [nb]: 0.324427311999416
  ```
- Miser (no event generation, 1'38" run):
  ```
  Integrated cross-section (value) [nb]: 4.71182617972158
  Integrated cross-section (uncertainty) [nb]: 0.0555660423376965
  ```
- Vegas (no event generation, 8'59" run):
  ```
  Integrated cross-section (value) [nb]: 4.74743323842268
  Integrated cross-section (uncertainty) [nb]: 0.00602654005686526
  ```